### PR TITLE
[QMK-3] Disable processing volume up/down when knob is held

### DIFF
--- a/keyboards/keychron/q2/rev_0111/rules.mk
+++ b/keyboards/keychron/q2/rev_0111/rules.mk
@@ -23,6 +23,7 @@ RGB_MATRIX_DRIVER = CKLED2001
 EEPROM_DRIVER = wear_leveling
 WEAR_LEVELING_DRIVER = embedded_flash
 ENCODER_MAP_ENABLE = no
+VIA_ENABLE = yes
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@
 
 - [QMK-1] Changed default keymap
 - [QMK-2] Faster volume steps
+- [QMK-3] Disable processing volume up/down when knob is held
 
 ### Future development plans
 


### PR DESCRIPTION
- enabled VIA
- disabled processing of volume up/down when knob is held (eg. after using press + rotate to change songs it will no longer change volume)