### PR TITLE
[QMK-4] Allow two rotations CCW with pressed knob to play song from the start of the previous song

### DIFF
--- a/keyboards/keychron/q2/rev_0111/keymaps/default/rotary-encoder.h
+++ b/keyboards/keychron/q2/rev_0111/keymaps/default/rotary-encoder.h
@@ -7,23 +7,29 @@
 
 #include QMK_KEYBOARD_H
 
-const int VOLUME_MULTIPLICATION = 2;
+const int VOLUME_MULTIPLICATION                    = 2;
+const int MAX_NUMBER_OF_CLOCKWISE_ROTATIONS        = 1;
+const int MAX_NUMBER_OF_COUNTERCLOCKWISE_ROTATIONS = 2;
 
-bool is_knob_pressed                   = false;
-bool should_send_play_pause_on_release = true;
-bool is_fn2_pressed                    = false;
-bool should_process_knob_press         = true;
+bool is_knob_pressed                      = false;
+bool should_send_play_pause_on_release    = true;
+int  number_of_clockwise_rotations        = 0;
+int  number_of_counterclockwise_rotations = 0;
+
+bool is_fn2_pressed = false;
 
 /* ------------------------------- knob press ------------------------------- */
 bool process_play_pause_rotary_encoder(keyrecord_t *record) {
     if (record->event.pressed) {
+        if (!is_knob_pressed) {
+            number_of_clockwise_rotations        = 0;
+            number_of_counterclockwise_rotations = 0;
+        }
         should_send_play_pause_on_release = true;
         is_knob_pressed                   = true;
-        should_process_knob_press         = true;
         return false;
     } else {
-        is_knob_pressed           = false;
-        should_process_knob_press = false;
+        is_knob_pressed = false;
         if (should_send_play_pause_on_release) {
             tap_code(DEFAULT_LAYER_KNOB_PRESS_ACTION);
         }
@@ -35,7 +41,7 @@ bool process_play_pause_rotary_encoder(keyrecord_t *record) {
 /* -------------------------------- FN2 press ------------------------------- */
 bool process_fn2_key(keyrecord_t *record) {
     if (record->event.pressed) {
-        is_fn2_pressed = true
+        is_fn2_pressed = true;
     } else {
         is_fn2_pressed = false;
     }
@@ -43,11 +49,21 @@ bool process_fn2_key(keyrecord_t *record) {
 }
 
 /* ------------------------------ knob rotation ----------------------------- */
+
+bool check_if_should_process_rotation(bool clockwise) {
+    if (clockwise) {
+        if (number_of_clockwise_rotations <= MAX_NUMBER_OF_CLOCKWISE_ROTATIONS) return true;
+        return false;
+    }
+    if (number_of_counterclockwise_rotations <= MAX_NUMBER_OF_COUNTERCLOCKWISE_ROTATIONS) return true;
+    return false;
+}
+
 void handle_knob_rotation(bool clockwise) {
     if (is_knob_pressed) {
-        if (!should_process_knob_press) return;
-        tap_code(clockwise ? KC_MNXT : KC_MPRV);
-        should_process_knob_press = false;
+        if (check_if_should_process_rotation(clockwise)) {
+            tap_code(clockwise ? KC_MNXT : KC_MPRV);
+        }
     } else {
         if (is_fn2_pressed) {
             clockwise ? rgblight_increase_val() : rgblight_decrease_val();
@@ -61,6 +77,11 @@ void handle_knob_rotation(bool clockwise) {
 
 /* ----------------- determine what should happen with knob ----------------- */
 bool encoder_update_user(uint8_t index, bool clockwise) {
+    if (clockwise) {
+        number_of_clockwise_rotations += 1;
+    } else {
+        number_of_counterclockwise_rotations += 1;
+    }
     handle_knob_rotation(clockwise);
     should_send_play_pause_on_release = false;
     return false;

--- a/readme.md
+++ b/readme.md
@@ -11,11 +11,12 @@
 - [QMK-1] Changed default keymap
 - [QMK-2] Faster volume steps
 - [QMK-3] Disable processing volume up/down when knob is held
+- [QMK-4] Allow two rotations CCW with pressed knob to play song from the start of the previous song
 
 ### Future development plans
 
+- CAPS-LOCK should enable SHIFT_LOCK
 - Remapping most of the useful shortcuts used in Power Toys -> key overrides
-- Moving to previous song with knob should allow to use it twice without releasing the press - first rotation for skipping to start of the song, second for skipping to the previous one
 - RGB presets
 - default RGB as one of the presets
 - Caps lock should change the RGB of the whole board to one of presets (red)


### PR DESCRIPTION
- allowed a different number of maximum rotation clockwise/counterclockwise when held